### PR TITLE
Add support in demo for docker workloads

### DIFF
--- a/demo/ScaleIO_Mesos_Testing_Cluster.json
+++ b/demo/ScaleIO_Mesos_Testing_Cluster.json
@@ -890,7 +890,7 @@
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "t2.medium",
-        "ImageId": "ami-2ecc834e",
+        "ImageId": "ami-4a2b652a",
         "Tags": [
           {
             "Key": "Name",
@@ -967,7 +967,7 @@
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "t2.medium",
-        "ImageId": "ami-cbc38cab",
+        "ImageId": "ami-39105e59",
         "Tags": [
           {
             "Key": "Name",


### PR DESCRIPTION
This updates the CloudFormation Template to preconfigure docker tasks for Mesos.
Also adds in code to the ScaleIO framework to preserve the preconfigured docker settings for Mesos.