### PR TITLE
Update scheduler with new states

### DIFF
--- a/scaleio-scheduler/types/types.go
+++ b/scaleio-scheduler/types/types.go
@@ -44,14 +44,20 @@ const (
 	//StatePrerequisitesInstalled the prerequisite packages are installed
 	StatePrerequisitesInstalled = 1
 
+	//StateCleanPrereqsReboot after kernel version has been updated
+	StateCleanPrereqsReboot = 2
+
 	//StateBasePackagedInstalled the base ScaleIO packages are installed
-	StateBasePackagedInstalled = 2
+	StateBasePackagedInstalled = 3
 
 	//StateInitializeCluster the cluster is setup, now initial the cluster
-	StateInitializeCluster = 3
+	StateInitializeCluster = 4
 
 	//StateInstallRexRay install rexray
-	StateInstallRexRay = 4
+	StateInstallRexRay = 5
+
+	//StateCleanInstallReboot after installing all components
+	StateCleanInstallReboot = 6
 
 	//StateFinishInstall the agent node installation is complete
 	StateFinishInstall = 1024


### PR DESCRIPTION
Adds a new state reboot if required. Those 2 conditions are, if rexray or the ScaleIO gateway had not previously been installed before. Reboot occurs at the end of setup. If rexray or the gateway had been installed before, no reboot is required.