### PR TITLE
Fix the restart of the Framework by correctly placing the marker file

### DIFF
--- a/scaleio-executor/executor/common/scaleionode.go
+++ b/scaleio-executor/executor/common/scaleionode.go
@@ -55,13 +55,13 @@ func (bsn *ScaleioNode) UpdateScaleIOState() *types.ScaleIOFramework {
 //LeaveMarkerFileForConfigured sets a marker file when in demo mode
 func (bsn *ScaleioNode) LeaveMarkerFileForConfigured() {
 	if !bsn.State.DemoMode {
-		log.Infoln("DemoMode = FALSE. Leaving marker file for previously configured")
+		log.Infoln("DemoMode = FALSE. Do not leave marker file")
 		return
 	}
 
 	log.Infoln("DemoMode = TRUE. Leaving marker file for previously configured")
 
-	err := os.MkdirAll("/etc/scaleio-framework", 0644)
+	err := os.MkdirAll("/etc/scaleio-framework", os.ModeDir)
 	if err != nil {
 		log.Errorln("Unable to mkdir:", err)
 	}

--- a/scaleio-executor/glide.yaml.dev
+++ b/scaleio-executor/glide.yaml.dev
@@ -11,6 +11,6 @@ import:
 - package: github.com/dvonthenen/goxplatform
   vcs:     git
 - package: github.com/codedellemc/scaleio-framework
-  ref:     8329826c54612ab9f7ecc24d3ddfca5133787a4f
+  ref:     ee2c9a8db12249aa06c019577dd5ac0ae25f4973
   vcs:     git
   repo:    https://github.com/dvonthenen/scaleio-framework


### PR DESCRIPTION
The marker file was not getting saved correctly which was interfering with launching the executor for restart.