### PR TITLE
Update Ubuntu 14.04 to ScaleIO 2.0.1

### DIFF
--- a/demo/Framework_Testing_Cluster_Ubuntu.json
+++ b/demo/Framework_Testing_Cluster_Ubuntu.json
@@ -813,7 +813,7 @@
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "t2.medium",
-        "ImageId": "ami-87a8e6e7",
+        "ImageId": "ami-1d85cf7d",
         "Tags": [
           {
             "Key": "Name",
@@ -890,7 +890,7 @@
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "t2.medium",
-        "ImageId": "ami-04aae464",
+        "ImageId": "ami-d69ad0b6",
         "Tags": [
           {
             "Key": "Name",
@@ -967,7 +967,7 @@
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "t2.medium",
-        "ImageId": "ami-dba8e6bb",
+        "ImageId": "ami-e89bd188",
         "Tags": [
           {
             "Key": "Name",

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # Demo/Test the ScaleIO Framework for Apache Mesos
 
-The requirements of having a 3-Node ScaleIO cluster along with an Apache Mesos Master and Agent cluster would heavily resource constrain a laptop or computer used for local development. An [AWS CloudFormation template](ScaleIO_Mesos_Testing_Cluster.json) is provided that deploys and installs a fully configured Dell EMC ScaleIO and Apache Mesos cluster on Amazon AWS. This template currently works in the **US-West-1 (aka N.California) region only**.
+The requirements of having a 3-Node ScaleIO cluster along with an Apache Mesos Master and Agent cluster would heavily resource constrain a laptop or computer used for local development. An [AWS CloudFormation template](Framework_Testing_Cluster_Ubuntu.json) is provided that deploys and installs a fully configured Dell EMC ScaleIO and Apache Mesos cluster on Amazon AWS. This template currently works in the **US-West-1 (aka N.California) region only**.
 
 *NOTE: Deploying this template uses six (6) `t2.medium` instances in the N.California region, costing $0.068/hour. The AWS EC2 compute usage for this cluster will cost approximately $9.78/day. The template provisions nine (9) EBS volumes in total. Six (6) for the operating systems and three (3) 100-gigabyte volumes for ScaleIO storage.*
 
@@ -22,7 +22,7 @@ Within the AWS Web GUI:
 1. Verify you are in the N. California region.
 2. Within the drop-down of `Services` choose `CloudFormation`
 3. Click `Create Stack`, then `Choose a Template`
-4. Click `Upload file to S3`, and upload [ScaleIO_Mesos_Testing_Cluster.json](ScaleIO_Mesos_Testing_Cluster.json)
+4. Click `Upload file to S3`, and upload [Framework_Testing_Cluster_Ubuntu.json](Framework_Testing_Cluster_Ubuntu.json)
 5. Give the stack a unique name (such as: MesosFrameworkDemo)
 6. Select a keypair that exists in the **N.California region**
 7. Click `next`. Tags are optional. Click `next`

--- a/scaleio-scheduler/config/config.go
+++ b/scaleio-scheduler/config/config.go
@@ -39,11 +39,11 @@ const (
 
 //consts internal
 const (
-	debMdm = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/EMC-ScaleIO-mdm-2.0-5014.0.Ubuntu.14.04.x86_64.deb"
-	debSds = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/EMC-ScaleIO-sds-2.0-5014.0.Ubuntu.14.04.x86_64.deb"
-	debSdc = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/EMC-ScaleIO-sdc-2.0-5014.0.Ubuntu.14.04.x86_64.deb"
-	debLia = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/EMC-ScaleIO-lia-2.0-5014.0.Ubuntu.14.04.x86_64.deb"
-	debGw  = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/emc-scaleio-gateway_2.0-5014.0_amd64.deb"
+	debMdm = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/EMC-ScaleIO-mdm-2.0-10000.2072.Ubuntu.14.04.x86_64.deb"
+	debSds = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/EMC-ScaleIO-sds-2.0-10000.2072.Ubuntu.14.04.x86_64.deb"
+	debSdc = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/EMC-ScaleIO-sdc-2.0-10000.2072.Ubuntu.14.04.x86_64.deb"
+	debLia = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/EMC-ScaleIO-lia-2.0-10000.2072.Ubuntu.14.04.x86_64.deb"
+	debGw  = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/emc-scaleio-gateway_2.0-10000.2072_amd64.deb"
 	rpmMdm = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/EMC-ScaleIO-mdm-2.0-10000.2072.el7.x86_64.rpm"
 	rpmSds = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/EMC-ScaleIO-sds-2.0-10000.2072.el7.x86_64.rpm"
 	rpmSdc = "https://github.com/codedellemc/scaleio-framework/releases/download/v0.1.0/EMC-ScaleIO-sdc-2.0-10000.2072.el7.x86_64.rpm"


### PR DESCRIPTION
Update CloudFormation template and default ScaleIO packages for Ubuntu14 to ScaleIO 2.0.1