### PR TITLE
Swap the AMIs to configure nodes with public dns hostnames

### DIFF
--- a/demo/Framework_Testing_Cluster_Ubuntu.json
+++ b/demo/Framework_Testing_Cluster_Ubuntu.json
@@ -813,7 +813,7 @@
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "t2.medium",
-        "ImageId": "ami-1d85cf7d",
+        "ImageId": "ami-a31445c3",
         "Tags": [
           {
             "Key": "Name",
@@ -890,7 +890,7 @@
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "t2.medium",
-        "ImageId": "ami-d69ad0b6",
+        "ImageId": "ami-ae1445ce",
         "Tags": [
           {
             "Key": "Name",
@@ -967,7 +967,7 @@
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "t2.medium",
-        "ImageId": "ami-e89bd188",
+        "ImageId": "ami-b71746d7",
         "Tags": [
           {
             "Key": "Name",


### PR DESCRIPTION
This addresses Issue https://github.com/codedellemc/scaleio-framework/issues/71. Instead of using elastic ips, we configure each mesos nodes to dynamically modify required files on boot and then start the mesos services.

