### PR TITLE
Add the rexray service name to the config

### DIFF
--- a/scaleio-executor/executor/pkgmgr/mgr/rexrayProcedural.go
+++ b/scaleio-executor/executor/pkgmgr/mgr/rexrayProcedural.go
@@ -194,6 +194,11 @@ func (nm *NodeManager) RexraySetup(state *types.ScaleIOFramework, executorID str
             operations:
               unmount:
                 ignoreUsedCount: true
+    rexray:
+      type: docker
+      libstorage:
+        service: scaleio
+      host: unix:///run/docker/plugins/rexray.sock
 libstorage:
   service: scaleio
   integration:


### PR DESCRIPTION
This is mainly to facilitate backwards compatibility.